### PR TITLE
Update description for cleaning cycle

### DIFF
--- a/custom_components/lifx/services.yaml
+++ b/custom_components/lifx/services.yaml
@@ -169,7 +169,7 @@ hev_cycle:
         boolean:
     duration:
       name: Duration
-      description: Duration of cleaning cycle. If unset, uses the default time of 2 hours.
+      description: Duration of cleaning cycle in seconds. If unset, uses the default time of 2 hours.
       selector:
         number:
           min: 0


### PR DESCRIPTION
Clarify the cycle duration is in seconds.

I spent a _long_ time troubleshooting my node-red automation, trying to work out why the HEV cycle would end after a few seconds. Turns out this value is in seconds, but I assumed it was hours since the HEV cycle requires long durations to clean anything.

Updating the description so it updates the Node-Red description :)