### PR TITLE
build(deps): bump aiolifx to 0.8.8 and aiolifx-themes to 0.4.1

### DIFF
--- a/custom_components/lifx/manifest.json
+++ b/custom_components/lifx/manifest.json
@@ -7,7 +7,7 @@
   "requirements": [
     "aiolifx==0.8.8",
     "aiolifx_effects==0.3.1",
-    "aiolifx_themes==0.4.0"
+    "aiolifx_themes==0.4.1"
   ],
   "quality_scale": "platinum",
   "dependencies": ["network"],

--- a/custom_components/lifx/manifest.json
+++ b/custom_components/lifx/manifest.json
@@ -1,11 +1,11 @@
 {
   "domain": "lifx",
   "name": "LIFX",
-  "version": "2023.2.0b1",
+  "version": "2023.2.0b2",
   "config_flow": true,
   "documentation": "https://github.com/Djelibeybi/ha-lifx-beta",
   "requirements": [
-    "aiolifx==0.8.7",
+    "aiolifx==0.8.8",
     "aiolifx_effects==0.3.1",
     "aiolifx_themes==0.4.0"
   ],


### PR DESCRIPTION
No functionality changes except for proper identification of the new
LIFX Downlights. Also includes the latest themes from the updated 
LIFX smart phone app.

Signed-off-by: Avi Miller <me@dje.li>